### PR TITLE
docs: Revive documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,6 @@
 # SUU_Linkerd
 
-Contents list
+In order to create and view documentation:
 
-1. [Introduction](#1-introduction)
-2. [Theoretical background](#2-theoretical-background-and-technology-stack)
-3. [Case study concept description](#3-case-study-concept-description)
-4. [Solution architecture](#4-solution-architecture)
-5. [Environment configuration description](#5-environment-configuration-description)
-6. [Installation method](#6-installation-method)
-7. [How to reproduce - step by step](#7-how-to-reproduce---step-by-step)
-8. [Demo deployment steps](#8-demo-deployment-steps)
-9. [Summary – conclusions](#9-summary--conclusions)
-10. [References](#10-references)
-
-## 1. Introduction
-## 2. Theoretical background and technology stack
-## 3. Case study concept description
-## 4. Solution architecture
-## 5. Environment configuration description
-## 6. Installation method
-## 7. How to reproduce - step by step
-### 1. Infrastructure as Code approach
-## 8. Demo deployment steps:
-### 1. Configuration set-up
-### 2. Data preparation
-### 3. Execution procedure
-### 4. Results presentation
-## 9. Summary – conclusions
-## 10. References
+cd docs
+make pdfdocs view

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,18 @@
+pdfdocs: docs.tex
+	@make clean
+	@pdflatex docs.tex
+	@pdflatex docs.tex
+	@bibtex docs.aux
+	@pdflatex docs.tex
+	@pdflatex docs.tex
+
+.PHONY: ed view clean
+
+ed:
+	@vim docs.tex
+
+view:
+	@evince docs.pdf
+
+clean:
+	@rm -f *.pdf *.toc *.aux *.log *.bbl *.blg

--- a/docs/bib.bib
+++ b/docs/bib.bib
@@ -1,0 +1,13 @@
+@misc{redhat:service-mesh,
+	author = {RedHat},
+	year = {June 29, 2018},
+	title = {What's a service mesh?},
+	howpublished = {\url{https://www.redhat.com/en/topics/microservices/what-is-a-service-mesh}}
+}
+
+@misc{linkerd:audit,
+	author = {William Morgan},
+	year = {June 27, 2022},
+	title = {Announcing the completion of Linkerd's 2022 Security Audit},
+	howpublished = {\url{https://linkerd.io/2022/06/27/announcing-the-completion-of-linkerds-2022-security-audit}}
+}

--- a/docs/docs.tex
+++ b/docs/docs.tex
@@ -1,0 +1,143 @@
+\documentclass{article}
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{tocloft}
+\usepackage{url}
+\bibliographystyle{abbrv}
+\author{Piotr Kica, Michał Grzelak, Antoni Gradowski, Jan Bugajski}
+\title{Linkerd-18: Linkerd Case Study}
+\date{\today, Group: 1}
+
+\begin{document}
+
+\maketitle
+\tableofcontents
+
+\section{Introduction}
+
+Linkerd is an cloud-native example of a service mesh -- which is a way to
+control how different parts of an application share data with one another.
+Unlike other systems for managing this communication, a service mesh is a
+dedicated infrastructure layer built right into an app. This visible
+infrastructure layer can document how well (or not) different parts of an app
+interact, so it becomes easier to optimize communication and avoid downtime as
+an app grows. \cite{redhat:service-mesh}
+
+\section{Theoretical background}
+
+Modern applications are often broken down as a network of services each
+performing a specific business function. In order to execute its function, one
+service might need to request data from several other services. But what if
+some services get overloaded with requests? This is where a service mesh comes
+in -- it routes requests from one service to the next, optimizing how all the
+moving parts work together.
+
+Service-to-service communication is what makes microservices possible. The
+logic governing communication can be coded into each service without a service
+mesh layer -- but as communication gets more complex, a service mesh becomes
+more valuable. For cloud-native apps built in a microservices architecture, a
+service mesh is a way to comprise a large number of discrete services into a
+functional application.
+
+A service mesh doesn't introduce new functionality to an app's runtime
+environment -- apps in any architecture have always needed rules to specify how
+requests get from point A to point B. What's different about a service mesh is
+that it takes the logic governing service-to-service communication out of
+individual services and abstracts it to a layer of infrastructure.
+
+In a service mesh, requests are routed between microservices through proxies in
+their own infrastructure layer. For this reason, individual proxies that make
+up a service mesh are sometimes called ``sidecars'' since they run alongside
+each service, rather than within them. Taken together, these ``sidecar''
+proxies -- decoupled from each service -- form a mesh network. A sidecar proxy
+sits alongside a microservice and routes requests to other proxies. Together,
+these sidecars form a mesh network.
+
+Without a service mesh, each microservice needs to be coded with logic to
+govern service-to-service communication, which means developers are less
+focused on business goals. It also means communication failures are harder to
+diagnose because the logic that governs interservice communication is hidden
+within each service.
+
+Every new service added to an app, or new instance of an existing service
+running in a container, complicates the communication environment and
+introduces new points of possible failure. Within a complex microservices
+architecture, it can become nearly impossible to locate where problems have
+occurred without a service mesh.
+
+That's because a service mesh also captures every aspect of service-to-service
+communication as performance metrics. Over time, data made visible by the
+service mesh can be applied to the rules for interservice communication,
+resulting in more efficient and reliable service requests.
+
+For example, if a given service fails, a service mesh can collect data on how
+long it took before a retry succeeded. As data on failure times for a given
+service aggregates, rules can be written to determine the optimal wait time
+before retrying that service, ensuring that the system does not become
+overburdened by unnecessary retries.
+
+\section{Case study concept description}
+
+Linkerd, with the use of proxy sidecars, is capable of service-to-service
+encryption. For that purpose it uses mTLS, which stands for mutual TLS.
+With the use of it every meshed service is capable of authenticating any
+request by a workload certificate derived from its Kubernetes ServiceAccount
+token.
+
+Without the usage of Linkerd, there is a risk of malicious eavesdropper which
+could sniff the communication, e.g. from a shared messaging platform thus exposing
+potentially sensitive data. Note that when using encryption provided by Linkerd,
+the risk is substantially lowered, which is pointed out in latest security audit:
+\cite{linkerd:audit}. One of the points of this case study is to show the difference.
+
+\section{Solution architecture}
+
+\section{Environment configuration description}
+
+\section{Installation method}
+
+\section{How to reproduce - step by step}
+
+\subsection{Infrastructure as Code approach}
+
+\section{Demo deployment steps:}
+
+\subsection{Configuration set-up}
+
+\subsection{Data preparation}
+
+\subsection{Execution procedure}
+
+\subsection{Results presentation}
+
+\section{Summary - conclusions}
+
+\section{Division of tasks}
+
+Team consisted of 4 members:
+
+\begin{itemize}
+		\item Piotr Kica;
+		\item Michał Grzelak;
+		\item Antoni Gradowski;
+		\item Jan Bugajski.
+\end{itemize}
+
+Piotr Kica created and managed the GitHub repository throughout the duration of
+the project. He was the first one who installed and successfully tested Linkerd
+on AWS instance. Moreover, Piotr came up with an idea of testing fault
+injection and observability guaranteed by Linkerd.
+
+Antoni Gradowski wrote draft layout of the documentation.
+
+Michał Grzelak added the first two chapters to this document, started third
+chapter and was responsible for transforming documentation's layout into
+\LaTeX. Furthermore, Michał came up with an idea of sniffing inter-service
+communication without Linkerd.
+
+Jan Bugajski was responsible for cleaning up and writing down ideas risen
+during brainstorms.
+
+\bibliography{bib}
+
+\end{document}


### PR DESCRIPTION
Transform documentation template from README.md into docs.tex. Add first 2. chapters and start 3. chapter. Add tasks division and basic bibliography. Change README.md into instruction how to create and view docs.